### PR TITLE
WIP: Add GPU builds

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,8 @@
 ucx_proc_type:
 - cpu
 - gpu
+nvcc_compiler:
+- nvcc
+nvcc_compiler_version:
+- 9.2
+- 10.0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,3 @@
 ucx_proc_type:
 - cpu
+- gpu

--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -7,6 +7,12 @@ export CONDA_BUILD_SYSROOT="$(${CC} --print-sysroot)"
 export CFLAGS="${CFLAGS} -I${CONDA_BUILD_SYSROOT}/usr/include"
 export LDFLAGS="${LDFLAGS} -L${CONDA_BUILD_SYSROOT}/usr/lib64"
 
+CUDA_CONFIG_ARG=""
+if [ ${ucx_proc_type} == "gpu" ]; then
+    export CFLAGS="${CFLAGS} -I${CUDA_HOME}/include"
+    CUDA_CONFIG_ARG="--with-cuda=${CUDA_HOME}"
+fi
+
 # Disable CMA to workaround an upstream bug.
 # xref: https://github.com/openucx/ucx/issues/3391
 # xref: https://github.com/openucx/ucx/pull/3424
@@ -19,7 +25,8 @@ export LDFLAGS="${LDFLAGS} -L${CONDA_BUILD_SYSROOT}/usr/lib64"
     --disable-cma \
     --enable-mt \
     --with-gnu-ld \
-    --with-rdmacm="/usr"
+    --with-rdmacm="/usr" \
+    ${CUDA_CONFIG_ARG}
 
 make -j${CPU_COUNT}
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
+        - {{ compiler("nvcc") }}         # [ucx_proc_type == "gpu"]
         - {{ cdt("libnl") }}
         - {{ cdt("libibverbs-devel") }}
         - {{ cdt("librdmacm-devel") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,8 @@ outputs:
     test:
       commands:
         - test -f "${PREFIX}/bin/ucx_info"
-        - ${PREFIX}/bin/ucx_info -v
+        # Requires driver for GPU test.
+        - ${PREFIX}/bin/ucx_info -v         # [ucx_proc_type != "gpu"]
     about:
       home: https://github.com/openucx/ucx
       license: BSD-3-Clause


### PR DESCRIPTION
This is still a WIP PR and as such no one should expect this to work as-is. There is some discussion about what still remains to be done below. That said, with a bit of work, it should be possible to build this locally.

This adds the GPU variant and configures the UCX build to use CUDA when the GPU variant is present.

Temporarily includes variants related to the `nvcc` compiler. Long term these will be moved to [conda-forge-pinning]( https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml ) so all users can benefit from these and individual feedstock maintainers can just use the `nvcc` compiler to get this functionality.

This require the [`nvcc` package]( https://github.com/conda-forge/nvcc-feedstock ) is built, which has not happened in conda-forge yet. Though we are gearing up for that work. People wanting to build this locally will need to build the `nvcc` package themselves and make sure that whatever channel they add it to is accessible from the build.

Have not sorted out the how the Docker images would be used by `nvcc` yet. This is being discussed in issue ( https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/237 ).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->