### PR TITLE
WIP: Add GPU builds with ucx-py

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,8 @@
 ucx_proc_type:
 - cpu
+- gpu
+nvcc_compiler:
+- nvcc
+nvcc_compiler_version:
+- 9.2
+- 10.0

--- a/recipe/install_ucx-py.sh
+++ b/recipe/install_ucx-py.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+cd "${SRC_DIR}/ucx-py"
+$PYTHON setup.py build_ext ${CUDA_CONFIG_ARG} install

--- a/recipe/install_ucx-py.sh
+++ b/recipe/install_ucx-py.sh
@@ -2,5 +2,11 @@
 
 set -xeuo pipefail
 
+CUDA_CONFIG_ARG=""
+if [ ${ucx_proc_type} == "gpu" ]; then
+    export CFLAGS="${CFLAGS} -I${CUDA_HOME}/include"
+    CUDA_CONFIG_ARG="--with-cuda"
+fi
+
 cd "${SRC_DIR}/ucx-py"
 $PYTHON setup.py build_ext ${CUDA_CONFIG_ARG} install

--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -7,6 +7,12 @@ export CONDA_BUILD_SYSROOT="$(${CC} --print-sysroot)"
 export CFLAGS="${CFLAGS} -I${CONDA_BUILD_SYSROOT}/usr/include"
 export LDFLAGS="${LDFLAGS} -L${CONDA_BUILD_SYSROOT}/usr/lib64"
 
+CUDA_CONFIG_ARG=""
+if [ ${ucx_proc_type} == "gpu" ]; then
+    export CFLAGS="${CFLAGS} -I${CUDA_HOME}/include"
+    CUDA_CONFIG_ARG="--with-cuda=${CUDA_HOME}"
+fi
+
 # Disable CMA to workaround an upstream bug.
 # xref: https://github.com/openucx/ucx/issues/3391
 # xref: https://github.com/openucx/ucx/pull/3424
@@ -20,7 +26,8 @@ cd "${SRC_DIR}/ucx"
     --disable-cma \
     --enable-mt \
     --with-gnu-ld \
-    --with-rdmacm="/usr"
+    --with-rdmacm="/usr" \
+    ${CUDA_CONFIG_ARG}
 
 make -j${CPU_COUNT}
 make install

--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -11,7 +11,8 @@ export LDFLAGS="${LDFLAGS} -L${CONDA_BUILD_SYSROOT}/usr/lib64"
 # xref: https://github.com/openucx/ucx/issues/3391
 # xref: https://github.com/openucx/ucx/pull/3424
 
-#./autogen.sh
+cd "${SRC_DIR}/ucx"
+./autogen.sh
 ./configure \
     --build="${BUILD}" \
     --host="${HOST}" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
+        - {{ compiler("nvcc") }}         # [ucx_proc_type == "gpu"]
         - {{ cdt("libnl") }}
         - {{ cdt("libibverbs-devel") }}
         - {{ cdt("librdmacm-devel") }}
@@ -59,7 +60,8 @@ outputs:
     test:
       commands:
         - test -f "${PREFIX}/bin/ucx_info"
-        - ${PREFIX}/bin/ucx_info -v
+        # Requires driver for GPU test.
+        - ${PREFIX}/bin/ucx_info -v         # [ucx_proc_type != "gpu"]
     about:
       home: https://github.com/openucx/ucx
       license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
-{% set ucx_version = "1.5.1" %}
-{% set number = "0" %}
+{% set ucx_version = "1.7.0.dev" %}
+{% set ucx_commit = "2d85597" %}  # from Akshay's ucx-cuda branch
+{% set number = "1" %}
 
 package:
   name: ucx-split
 
 source:
-  url: https://github.com/openucx/ucx/releases/download/v{{ ucx_version }}/ucx-{{ ucx_version }}.tar.gz
-  sha256: 567119cd80ad2ae6968ecaa4bd1d2a80afadd037ccc988740f668de10d2fdb7e
+  git_url: https://github.com/Akshay-Venkatesh/ucx
+  git_rev: {{ ucx_commit }}
 
 build:
   skip: true  # [not linux]
@@ -28,7 +29,7 @@ outputs:
       summary: A meta-package to select CPU or GPU UCX build.
 
   - name: ucx
-    version: {{ ucx_version }}
+    version: "{{ ucx_version }}{{ number }}+g{{ ucx_commit }}"
     build:
       number: {{ number }}
       string: "h{{ PKG_HASH }}_{{ number }}_{{ ucx_proc_type }}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -99,6 +99,7 @@ outputs:
         - ucp
     about:
       home: https://github.com/rapidsai/ucx-py
+      license_file: LICENSE
       summary: Python bindings for UCX
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,6 +79,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
+        - {{ compiler("nvcc") }}         # [ucx_proc_type == "gpu"]
         - {{ cdt("libnl") }}
         - {{ cdt("libibverbs") }}
         - {{ cdt("librdmacm") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,19 @@
 {% set ucx_version = "1.7.0.dev" %}
 {% set ucx_commit = "2d85597" %}  # from Akshay's ucx-cuda branch
+{% set ucx_py_version = "0.1.0.dev" %}
+{% set ucx_py_commit = "7d37e7e" %}  # from rapidsai's devel branch
 {% set number = "1" %}
 
 package:
   name: ucx-split
 
 source:
-  git_url: https://github.com/Akshay-Venkatesh/ucx
-  git_rev: {{ ucx_commit }}
+  - git_url: https://github.com/Akshay-Venkatesh/ucx
+    git_rev: {{ ucx_commit }}
+    folder: ucx
+  - git_url: https://github.com/rapidsai/ucx-py
+    git_rev: {{ ucx_py_commit }}
+    folder: ucx-py
 
 build:
   skip: true  # [not linux]
@@ -58,8 +64,39 @@ outputs:
       home: https://github.com/openucx/ucx
       license: BSD-3-Clause
       license_family: BSD
-      license_file: LICENSE
+      license_file: ucx/LICENSE
       summary: Unified Communication X.
+
+  - name: ucx-py
+    version: "{{ ucx_py_version }}{{ number }}+g{{ ucx_py_commit }}"
+    build:
+      number: {{ number }}
+      skip: true  # [py<36]
+      string: "py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ number }}_{{ ucx_proc_type }}"
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
+        - {{ cdt("libnl") }}
+        - {{ cdt("libibverbs") }}
+        - {{ cdt("librdmacm") }}
+      host:
+        - python
+        - setuptools
+        - cython
+        - ucx
+      run:
+        - python
+        - {{ pin_subpackage("ucx", exact=True) }}
+      run_constrained:
+        - ucx-proc * {{ ucx_proc_type }}
+    script: install_ucx-py.sh
+    test:
+      imports:
+        - ucp
+    about:
+      home: https://github.com/rapidsai/ucx-py
+      summary: Python bindings for UCX
 
 about:
   home: https://github.com/openucx/ucx

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set ucx_version = "1.7.0.dev" %}
-{% set ucx_commit = "2d85597" %}  # from Akshay's ucx-cuda branch
+{% set ucx_commit = "9275db5" %}  # from Akshay's ucx-cuda branch
 {% set ucx_py_version = "0.1.0.dev" %}
-{% set ucx_py_commit = "7d37e7e" %}  # from rapidsai's devel branch
-{% set number = "1" %}
+{% set ucx_py_commit = "c93687a" %}  # from rapidsai's devel branch
+{% set number = "2" %}
 
 package:
   name: ucx-split


### PR DESCRIPTION
This is essentially an amalgamation of PRs ( https://github.com/conda-forge/ucx-split-feedstock/pull/2 , https://github.com/conda-forge/ucx-split-feedstock/pull/3 , and https://github.com/conda-forge/ucx-split-feedstock/pull/4 ).

Adds in GPU builds of UCX and builds a development version of UCX with ucx-py. This is roughly what we use to build UCX packages for RAPIDS today.

cc @mrocklin

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->