### PR TITLE
Drop `ucx_proc_type` variant and use Jinja instead

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -12,5 +12,3 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-ucx_proc_type:
-- cpu

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,2 @@
-ucx_proc_type:
-- cpu
 docker_image:
 - condaforge/linux-anvil-comp7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,9 @@
 {% set ucx_version = "1.5.1" %}
 {% set number = "0" %}
 
+{% set ucx_proc_type = "cpu" %}
+
+
 package:
   name: ucx-split
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set ucx_version = "1.5.1" %}
-{% set number = "0" %}
+{% set number = "1" %}
 
 {% set ucx_proc_type = "cpu" %}
 


### PR DESCRIPTION
When adding the CUDA versions, it is already possible and useful to handle cases where a CPU-only build is generated. Having this variant in addition to CUDA versions results in an overcomplete spanning of this space. So eliminate `ucx_proc_type` as a variant and instead set it in Jinja as a convenience for use in the recipe.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
