### PR TITLE
Add GPU builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,10 +10,22 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_:
-        CONFIG: linux_
+      linux_cuda_compiler_version:
+        CONFIG: linux_cuda_compiler_version
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_cuda_compiler_version10.0:
+        CONFIG: linux_cuda_compiler_version10.0
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.0
+      linux_cuda_compiler_version10.1:
+        CONFIG: linux_cuda_compiler_version10.1
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.1
+      linux_cuda_compiler_version9.2:
+        CONFIG: linux_cuda_compiler_version9.2
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:9.2
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,10 +10,6 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_cuda_compiler_version:
-        CONFIG: linux_cuda_compiler_version
-        UPLOAD_PACKAGES: True
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
       linux_cuda_compiler_version10.0:
         CONFIG: linux_cuda_compiler_version10.0
         UPLOAD_PACKAGES: True
@@ -26,6 +22,10 @@ jobs:
         CONFIG: linux_cuda_compiler_version9.2
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:9.2
+      linux_cuda_compiler_versionNone:
+        CONFIG: linux_cuda_compiler_versionNone
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static

--- a/.ci_support/linux_cuda_compiler_version.yaml
+++ b/.ci_support/linux_cuda_compiler_version.yaml
@@ -1,0 +1,21 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- ''
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.0.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.0.yaml
@@ -1,0 +1,21 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '10.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-cuda:10.0
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.1.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.1.yaml
@@ -1,0 +1,21 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '10.1'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-cuda:10.1
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_version9.2.yaml
+++ b/.ci_support/linux_cuda_compiler_version9.2.yaml
@@ -6,9 +6,16 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '9.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-cuda:9.2
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_cuda_compiler_versionNone.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- ''
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/README.md
+++ b/README.md
@@ -29,13 +29,6 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_cuda_compiler_version</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_cuda_compiler_version10.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">
@@ -54,6 +47,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version9.2" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_versionNone</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_versionNone" alt="variant">
                 </a>
               </td>
             </tr>

--- a/README.md
+++ b/README.md
@@ -29,10 +29,31 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux</td>
+              <td>linux_cuda_compiler_version</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_version10.0</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.0" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_version10.1</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_version9.2</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version9.2" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- ""
+- None
 - 9.2
 - 10.0
 - 10.1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,15 @@
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
+- ""
 - 9.2
 - 10.0
 - 10.1
 docker_image:
 - condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-cuda:9.2
+- condaforge/linux-anvil-cuda:10.0
+- condaforge/linux-anvil-cuda:10.1
+zip_keys:
+  - - cuda_compiler_version
+    - docker_image

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,8 @@
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- 9.2
+- 10.0
+- 10.1
 docker_image:
 - condaforge/linux-anvil-comp7

--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -9,7 +9,6 @@ export LDFLAGS="${LDFLAGS} -L${CONDA_BUILD_SYSROOT}/usr/lib64"
 
 CUDA_CONFIG_ARG=""
 if [ ${cuda_compiler_version} != "" ]; then
-    export CFLAGS="${CFLAGS} -I${CUDA_HOME}/include"
     CUDA_CONFIG_ARG="--with-cuda=${CUDA_HOME}"
 fi
 

--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -8,7 +8,7 @@ export CFLAGS="${CFLAGS} -I${CONDA_BUILD_SYSROOT}/usr/include"
 export LDFLAGS="${LDFLAGS} -L${CONDA_BUILD_SYSROOT}/usr/lib64"
 
 CUDA_CONFIG_ARG=""
-if [ ${cuda_compiler_version} != "" ]; then
+if [ ${cuda_compiler_version} != "None" ]; then
     CUDA_CONFIG_ARG="--with-cuda=${CUDA_HOME}"
 fi
 

--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -7,6 +7,12 @@ export CONDA_BUILD_SYSROOT="$(${CC} --print-sysroot)"
 export CFLAGS="${CFLAGS} -I${CONDA_BUILD_SYSROOT}/usr/include"
 export LDFLAGS="${LDFLAGS} -L${CONDA_BUILD_SYSROOT}/usr/lib64"
 
+CUDA_CONFIG_ARG=""
+if [ ${cuda_compiler_version} != "" ]; then
+    export CFLAGS="${CFLAGS} -I${CUDA_HOME}/include"
+    CUDA_CONFIG_ARG="--with-cuda=${CUDA_HOME}"
+fi
+
 # Disable CMA to workaround an upstream bug.
 # xref: https://github.com/openucx/ucx/issues/3391
 # xref: https://github.com/openucx/ucx/pull/3424
@@ -19,7 +25,8 @@ export LDFLAGS="${LDFLAGS} -L${CONDA_BUILD_SYSROOT}/usr/lib64"
     --disable-cma \
     --enable-mt \
     --with-gnu-ld \
-    --with-rdmacm="/usr"
+    --with-rdmacm="/usr" \
+    ${CUDA_CONFIG_ARG}
 
 make -j${CPU_COUNT}
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
+        - {{ compiler("cuda") }}         # [cuda_compiler_version != ""]
         - {{ cdt("libnl") }}
         - {{ cdt("libibverbs-devel") }}
         - {{ cdt("librdmacm-devel") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set ucx_version = "1.5.1" %}
 {% set number = "1" %}
 
-{% set ucx_proc_type = "cpu" %}
+{% set ucx_proc_type = "cpu" if cuda_compiler_version == "" else "gpu" %}
 
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set ucx_version = "1.5.1" %}
 {% set number = "1" %}
 
-{% set ucx_proc_type = "cpu" if cuda_compiler_version == "" else "gpu" %}
+{% set ucx_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}
 
 
 package:
@@ -42,7 +42,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - {{ compiler("cuda") }}         # [cuda_compiler_version != ""]
+        - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
         - {{ cdt("libnl") }}
         - {{ cdt("libibverbs-devel") }}
         - {{ cdt("librdmacm-devel") }}
@@ -60,7 +60,7 @@ outputs:
       commands:
         - test -f "${PREFIX}/bin/ucx_info"
         # Requires driver for GPU test.
-        - ${PREFIX}/bin/ucx_info -v         # [cuda_compiler_version == ""]
+        - ${PREFIX}/bin/ucx_info -v         # [cuda_compiler_version == "None"]
     about:
       home: https://github.com/openucx/ucx
       license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,9 @@ outputs:
       license: BSD-3-Clause
       license_family: BSD
       summary: A meta-package to select CPU or GPU UCX build.
+    extra:
+      variants:
+        cuda_compiler_version: {{ cuda_compiler_version }}
 
   - name: ucx
     version: {{ ucx_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,8 @@ outputs:
     test:
       commands:
         - test -f "${PREFIX}/bin/ucx_info"
-        - ${PREFIX}/bin/ucx_info -v
+        # Requires driver for GPU test.
+        - ${PREFIX}/bin/ucx_info -v         # [cuda_compiler_version == ""]
     about:
       home: https://github.com/openucx/ucx
       license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,9 +29,6 @@ outputs:
       license: BSD-3-Clause
       license_family: BSD
       summary: A meta-package to select CPU or GPU UCX build.
-    extra:
-      variants:
-        cuda_compiler_version: {{ cuda_compiler_version }}
 
   - name: ucx
     version: {{ ucx_version }}


### PR DESCRIPTION
Here we add GPU builds of the `ucx` package. Builds out all CUDA versions available. The CPU-only package is retained in this process. Users are able to select between the two using the `ucx-proc` package.

This is somewhat exploratory in how variants are used to get the feedstock re-rendered as intended for CI. Hopefully this can be refined over time and [integrated into `conda-forge-pinning`]( https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/b3a44e00185b3d19bcc11595597acf8945bd2b6a/recipe/conda_build_config.yaml#L120 ). For now we will keep this logic here to making the iterations of refinement tighter.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Closes https://github.com/conda-forge/ucx-split-feedstock/pull/2
Closes https://github.com/conda-forge/ucx-split-feedstock/pull/6

<!--
Please add any other relevant info below:
-->
