### PR TITLE
Skip setting rdmacm path in `./configure`

### DIFF
--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -24,7 +24,7 @@ fi
     --disable-cma \
     --enable-mt \
     --with-gnu-ld \
-    --with-rdmacm="/usr" \
+    --with-rdmacm \
     ${CUDA_CONFIG_ARG}
 
 make -j${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set ucx_version = "1.5.1" %}
-{% set number = "1" %}
+{% set number = "2" %}
 
 {% set ucx_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}
 


### PR DESCRIPTION
This was originally needed to build the package when the recipe was first being updated. Though it may not be strictly necessary at this stage. In particular CDTs have been built out and added as dependencies for rdmacm (amongst other system level dependencies that UCX has). So try dropping this explicit path to see if things still work.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->