### PR TITLE
Factor our `ucx_proc`'s version with Jinja

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set ucx_version = "1.5.1" %}
+{% set ucx_proc_version = "1.0.0" %}
 {% set number = "1" %}
 
 {% set ucx_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}
@@ -17,7 +18,7 @@ build:
 
 outputs:
   - name: ucx-proc
-    version: 1.0.0
+    version: {{ ucx_proc_version }}
     build:
       number: 0
       string: "{{ ucx_proc_type }}"


### PR DESCRIPTION
Should avoid the bot getting hung up on this UCX version.

Edit: Changing build number is unneeded as this doesn't affect the package itself.

xref: https://github.com/regro/cf-scripts/issues/567

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
