### PR TITLE
Drop unneeded commented code

### DIFF
--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -16,7 +16,6 @@ fi
 # xref: https://github.com/openucx/ucx/issues/3391
 # xref: https://github.com/openucx/ucx/pull/3424
 
-#./autogen.sh
 ./configure \
     --build="${BUILD}" \
     --host="${HOST}" \


### PR DESCRIPTION
There is no need to run `autogen.sh` on published release artifacts where this has already been done for us. So this line has remained commented. It's only really needed for dev builds where we already add this line. So in the interest of keeping things easy to understand, drop this already commented line.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
