### PR TITLE
Bump the right build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set ucx_version = "1.6.1" %}
 {% set ucx_proc_version = "1.0.0" %}
-{% set number = "0" %}
+{% set number = "1" %}
 
 {% set ucx_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}
 
@@ -21,7 +21,7 @@ source:
 
 build:
   skip: true  # [not linux]
-  number: 1
+  number: 0
 
 outputs:
   - name: ucx-proc


### PR DESCRIPTION
Accidentally bumped the build number for the split package as a whole even though that is not actually used for anything. This makes the build number bump on the `ucx` package and resets the build number for the split package to 0.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
