### PR TITLE
Drop custom build strings

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set ucx_version = "1.6.1" %}
 {% set ucx_proc_version = "1.0.0" %}
-{% set number = "1" %}
+{% set number = "2" %}
 
 {% set ucx_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,6 @@ outputs:
     version: {{ ucx_version }}
     build:
       number: {{ number }}
-      string: "h{{ PKG_HASH }}_{{ number }}_{{ ucx_proc_type }}"
     requirements:
       build:
         - {{ compiler("c") }}


### PR DESCRIPTION
As the CUDA version and whether the package is CPU or GPU is already included in the package hash correctly, go ahead and drop the custom build strings in packages. This info can be determined by looking at the `cudatoolkit` version and `ucx-proc` package installed. Alternatively they can be determined by running `conda inspect hash-inputs` on the packages. Dropping the custom build strings should make this a bit easier to maintain.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
