### PR TITLE
Release ucx-py 0.2 and apply a couple patches to ucx

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set ucx_version = "1.7.0-rc1" %}
 {% set ucx_proc_version = "1.0.0" %}
-{% set ucx_py_version = "0.1" %}
+{% set ucx_py_version = "0.2" %}
 {% set number = "1" %}
 
 {% set ucx_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}
@@ -17,7 +17,7 @@ source:
       - patches/PR_4383.patch
       - patches/PR_4384.patch
   - url: https://github.com/rapidsai/ucx-py/archive/{{ ucx_py_version }}.tar.gz
-    sha256: b19ff22ea4111afaaace05e9a6594e97776fac7fb04f7c2018a274a3dd57b53f
+    sha256: c8b06f67d1cff2e33ce2d264c9e947e6a33b0d14b0399f66508473c65654da04
     folder: ucx-py
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,9 @@ source:
   - url: https://github.com/openucx/ucx/archive/v{{ ucx_version }}.tar.gz
     sha256: a9598abd5c697e4a49a512b285c5747413d1f45155a12ecb1f5ee389c0459afa
     folder: ucx
+    patches:
+      - patches/PR_4383.patch
+      - patches/PR_4384.patch
   - url: https://github.com/rapidsai/ucx-py/archive/{{ ucx_py_version }}.tar.gz
     sha256: b19ff22ea4111afaaace05e9a6594e97776fac7fb04f7c2018a274a3dd57b53f
     folder: ucx-py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set ucx_version = "1.7.0-rc1" %}
 {% set ucx_proc_version = "1.0.0" %}
 {% set ucx_py_version = "0.1" %}
-{% set number = "0" %}
+{% set number = "1" %}
 
 {% set ucx_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}
 

--- a/recipe/patches/PR_4383.patch
+++ b/recipe/patches/PR_4383.patch
@@ -1,0 +1,73 @@
+From 943a7c39add4be1456c26448f839cbd1d66ea787 Mon Sep 17 00:00:00 2001
+From: Peter Andreas Entschev <peter@entschev.com>
+Date: Wed, 30 Oct 2019 06:25:39 -0700
+Subject: [PATCH] UCM/CUDA: Skip ucm_cuda_set_ptr_attr when pointer is null
+
+---
+ src/ucm/cuda/cudamem.c | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/src/ucm/cuda/cudamem.c b/src/ucm/cuda/cudamem.c
+index 078ded45b1..907f7e51db 100644
+--- a/src/ucm/cuda/cudamem.c
++++ b/src/ucm/cuda/cudamem.c
+@@ -66,6 +66,11 @@ UCM_OVERRIDE_FUNC(cudaHostUnregister,        cudaError_t)
+ 
+ static void ucm_cuda_set_ptr_attr(CUdeviceptr dptr)
+ {
++    if ((void*)dptr == NULL) {
++        ucm_trace("skipping cuPointerSetAttribute for null pointer");
++        return;
++    }
++
+     unsigned int value = 1;
+     CUresult ret;
+     const char *cu_err_str;
+@@ -161,10 +166,9 @@ CUresult ucm_cuMemAlloc(CUdeviceptr *dptr, size_t size)
+     if (ret == CUDA_SUCCESS) {
+         ucm_trace("ucm_cuMemAlloc(dptr=%p size:%lu)",(void *)*dptr, size);
+         ucm_dispatch_mem_type_alloc((void *)*dptr, size, UCS_MEMORY_TYPE_CUDA);
++        ucm_cuda_set_ptr_attr(*dptr);
+     }
+ 
+-    ucm_cuda_set_ptr_attr(*dptr);
+-
+     ucm_event_leave();
+     return ret;
+ }
+@@ -201,10 +205,9 @@ CUresult ucm_cuMemAllocPitch(CUdeviceptr *dptr, size_t *pPitch,
+                   (WidthInBytes * Height));
+         ucm_dispatch_mem_type_alloc((void *)*dptr, WidthInBytes * Height,
+                                     UCS_MEMORY_TYPE_CUDA);
++        ucm_cuda_set_ptr_attr(*dptr);
+     }
+ 
+-    ucm_cuda_set_ptr_attr(*dptr);
+-
+     ucm_event_leave();
+     return ret;
+ }
+@@ -281,10 +284,9 @@ cudaError_t ucm_cudaMalloc(void **devPtr, size_t size)
+     if (ret == cudaSuccess) {
+         ucm_trace("ucm_cudaMalloc(devPtr=%p size:%lu)", *devPtr, size);
+         ucm_dispatch_mem_type_alloc(*devPtr, size, UCS_MEMORY_TYPE_CUDA);
++        ucm_cuda_set_ptr_attr((CUdeviceptr) *devPtr);
+     }
+ 
+-    ucm_cuda_set_ptr_attr((CUdeviceptr) *devPtr);
+-
+     ucm_event_leave();
+ 
+     return ret;
+@@ -319,10 +321,9 @@ cudaError_t ucm_cudaMallocPitch(void **devPtr, size_t *pitch,
+     if (ret == cudaSuccess) {
+         ucm_trace("ucm_cudaMallocPitch(devPtr=%p size:%lu)",*devPtr, (width * height));
+         ucm_dispatch_mem_type_alloc(*devPtr, (width * height), UCS_MEMORY_TYPE_CUDA);
++        ucm_cuda_set_ptr_attr((CUdeviceptr) *devPtr);
+     }
+ 
+-    ucm_cuda_set_ptr_attr((CUdeviceptr) *devPtr);
+-
+     ucm_event_leave();
+     return ret;
+ }

--- a/recipe/patches/PR_4384.patch
+++ b/recipe/patches/PR_4384.patch
@@ -1,0 +1,31 @@
+From b0788ec33a8c03d151bc3fdc11f4615fce7fff65 Mon Sep 17 00:00:00 2001
+From: Peter Andreas Entschev <peter@entschev.com>
+Date: Fri, 1 Nov 2019 06:38:30 -0700
+Subject: [PATCH] UCM/CUDA: fix ucm_cudafree_dispatch_events assertion
+
+Only call assert in ucm_cudafree_dispatch_events if cuMemGetAddressRange() call
+succeeds and downgrade warning to debug message when it fails.
+---
+ src/ucm/cuda/cudamem.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/ucm/cuda/cudamem.c b/src/ucm/cuda/cudamem.c
+index 078ded45b1..ad127dbda5 100644
+--- a/src/ucm/cuda/cudamem.c
++++ b/src/ucm/cuda/cudamem.c
+@@ -110,11 +110,12 @@ static void ucm_cudafree_dispatch_events(void *dptr)
+     }
+ 
+     ret = cuMemGetAddressRange(&pbase, &psize, (CUdeviceptr) dptr);
+-    if (ret != CUDA_SUCCESS) {
+-        ucm_warn("cuMemGetAddressRange(devPtr=%p) failed", (void *)dptr);
++    if (ret == CUDA_SUCCESS) {
++        ucs_assert(dptr == (void *)pbase);
++    } else {
++        ucm_debug("cuMemGetAddressRange(devPtr=%p) failed", (void *)dptr);
+         psize = 1; /* set minimum length */
+     }
+-    ucs_assert(dptr == (void *)pbase);
+ 
+     ucm_dispatch_mem_type_free((void *)dptr, psize, UCS_MEMORY_TYPE_CUDA);
+ }


### PR DESCRIPTION
Bumps ucx-py to version 0.2 and adds a couple upstream patches to the ucx build.

cc @quasiben @pentschev @madsbk

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Closes https://github.com/rapidsai/ucx-py/issues/298

<!--
Please add any other relevant info below:
-->
