### PR TITLE
Build using `./configure`'s `--with-sysroot` flag

### DIFF
--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -21,6 +21,7 @@ fi
     --build="${BUILD}" \
     --host="${HOST}" \
     --prefix="${PREFIX}" \
+    --with-sysroot \
     --disable-cma \
     --enable-mt \
     --with-gnu-ld \

--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -2,11 +2,6 @@
 
 set -xeuo pipefail
 
-export CONDA_BUILD_SYSROOT="$(${CC} --print-sysroot)"
-
-export CFLAGS="${CFLAGS} -I${CONDA_BUILD_SYSROOT}/usr/include"
-export LDFLAGS="${LDFLAGS} -L${CONDA_BUILD_SYSROOT}/usr/lib64"
-
 CUDA_CONFIG_ARG=""
 if [ ${cuda_compiler_version} != "None" ]; then
     CUDA_CONFIG_ARG="--with-cuda=${CUDA_HOME}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set ucx_version = "1.6.1" %}
 {% set ucx_proc_version = "1.0.0" %}
-{% set number = "4" %}
+{% set number = "5" %}
 
 {% set ucx_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}
 


### PR DESCRIPTION
To simplify the build a little bit, add the `--with-sysroot` flag to `./configure`. Should avoid needing to add these paths to library and header search paths generally.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
