### PR TITLE
Drop NUMA CDT

### DIFF
--- a/.ci_support/linux_64_c_compiler_version10cdt_namecos7cuda_compiler_version11.1cxx_compiler_version10.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cdt_namecos7cuda_compiler_version11.1cxx_compiler_version10.yaml
@@ -21,7 +21,7 @@ docker_image:
 target_platform:
 - linux-64
 ucx:
-- 1.12.1
+- 1.14.0
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version10cdt_namecos7cuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cdt_namecos7cuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -21,7 +21,7 @@ docker_image:
 target_platform:
 - linux-64
 ucx:
-- 1.12.1
+- 1.14.0
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version7cdt_namecos6cuda_compiler_version10.2cxx_compiler_version7.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cdt_namecos6cuda_compiler_version10.2cxx_compiler_version7.yaml
@@ -21,7 +21,7 @@ docker_image:
 target_platform:
 - linux-64
 ucx:
-- 1.12.1
+- 1.14.0
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version9cdt_namecos7cuda_compiler_version11.0cxx_compiler_version9.yaml
+++ b/.ci_support/linux_64_c_compiler_version9cdt_namecos7cuda_compiler_version11.0cxx_compiler_version9.yaml
@@ -21,7 +21,7 @@ docker_image:
 target_platform:
 - linux-64
 ucx:
-- 1.12.1
+- 1.14.0
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -25,7 +25,7 @@ docker_image:
 target_platform:
 - linux-aarch64
 ucx:
-- 1.12.1
+- 1.14.0
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -21,7 +21,7 @@ docker_image:
 target_platform:
 - linux-ppc64le
 ucx:
-- 1.12.1
+- 1.14.0
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ outputs:
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
         - {{ cdt("libnl") }}             # [cdt_name == "cos6"]
         - {{ cdt("libnl3") }}            # [cdt_name == "cos7"]
-        - {{ cdt("numactl-devel") }}
         - automake
         - autoconf
         - libtool

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set ucx_version = "1.14.0" %}
-{% set number = "0" %}
+{% set number = "1" %}
 
 
 package:


### PR DESCRIPTION
As the NUMA dependency is now satisfied by the `libnuma` package, drop `{{ cdt("numactl-devel") }}`.

xref: https://github.com/conda-forge/ucx-split-feedstock/pull/111#discussion_r1164529771

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
