### PR TITLE
[NO MRG] Testing "Add `cuda_compiler` to `zip_keys`"

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,20 +8,20 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_c_compiler_version10cdt_namecos7cuda_compiler_version11.1cxx_compiler_version10:
-        CONFIG: linux_64_c_compiler_version10cdt_namecos7cuda_compiler_version11.1cxx_compiler_version10
+      linux_64_c_compiler_version10cdt_namecos7cuda_compilernvcccuda_compiler_version11.1cxx_compiler_version10:
+        CONFIG: linux_64_c_compiler_version10cdt_namecos7cuda_compilernvcccuda_compiler_version11.1cxx_compiler_version10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.1
-      linux_64_c_compiler_version10cdt_namecos7cuda_compiler_version11.2cxx_compiler_version10:
-        CONFIG: linux_64_c_compiler_version10cdt_namecos7cuda_compiler_version11.2cxx_compiler_version10
+      linux_64_c_compiler_version10cdt_namecos7cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10:
+        CONFIG: linux_64_c_compiler_version10cdt_namecos7cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
-      linux_64_c_compiler_version7cdt_namecos6cuda_compiler_version10.2cxx_compiler_version7:
-        CONFIG: linux_64_c_compiler_version7cdt_namecos6cuda_compiler_version10.2cxx_compiler_version7
+      linux_64_c_compiler_version7cdt_namecos6cuda_compilernvcccuda_compiler_version10.2cxx_compiler_version7:
+        CONFIG: linux_64_c_compiler_version7cdt_namecos6cuda_compilernvcccuda_compiler_version10.2cxx_compiler_version7
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-cuda:10.2
-      linux_64_c_compiler_version9cdt_namecos7cuda_compiler_version11.0cxx_compiler_version9:
-        CONFIG: linux_64_c_compiler_version9cdt_namecos7cuda_compiler_version11.0cxx_compiler_version9
+      linux_64_c_compiler_version9cdt_namecos7cuda_compilernvcccuda_compiler_version11.0cxx_compiler_version9:
+        CONFIG: linux_64_c_compiler_version9cdt_namecos7cuda_compilernvcccuda_compiler_version11.0cxx_compiler_version9
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.0
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_c_compiler_version10cdt_namecos7cuda_compilernvcccuda_compiler_version11.1cxx_compiler_version10.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cdt_namecos7cuda_compilernvcccuda_compiler_version11.1cxx_compiler_version10.yaml
@@ -11,13 +11,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '11.2'
+- '11.1'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '10'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:11.2
+- quay.io/condaforge/linux-anvil-cuda:11.1
 target_platform:
 - linux-64
 ucx:
@@ -25,6 +25,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version10cdt_namecos7cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cdt_namecos7cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -1,9 +1,9 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '10'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,13 +11,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.2'
+- '11.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '10'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-cuda:10.2
+- quay.io/condaforge/linux-anvil-cuda:11.2
 target_platform:
 - linux-64
 ucx:
@@ -25,6 +25,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version7cdt_namecos6cuda_compilernvcccuda_compiler_version10.2cxx_compiler_version7.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cdt_namecos6cuda_compilernvcccuda_compiler_version10.2cxx_compiler_version7.yaml
@@ -1,9 +1,9 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '9'
+- '7'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,13 +11,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '11.0'
+- '10.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '9'
+- '7'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:11.0
+- quay.io/condaforge/linux-anvil-cos7-cuda:10.2
 target_platform:
 - linux-64
 ucx:
@@ -25,6 +25,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version9cdt_namecos7cuda_compilernvcccuda_compiler_version11.0cxx_compiler_version9.yaml
+++ b/.ci_support/linux_64_c_compiler_version9cdt_namecos7cuda_compilernvcccuda_compiler_version11.0cxx_compiler_version9.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '9'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,13 +11,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '11.1'
+- '11.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:11.1
+- quay.io/condaforge/linux-anvil-cuda:11.0
 target_platform:
 - linux-64
 ucx:
@@ -25,6 +25,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -1,7 +1,11 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '10'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -17,14 +21,15 @@ cxx_compiler:
 cxx_compiler_version:
 - '10'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2
+- quay.io/condaforge/linux-anvil-aarch64-cuda:11.2
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 ucx:
 - 1.14.0
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_ppc64le_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -1,11 +1,7 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '10'
-cdt_arch:
-- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -21,14 +17,15 @@ cxx_compiler:
 cxx_compiler_version:
 - '10'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64-cuda:11.2
+- quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2
 target_platform:
-- linux-aarch64
+- linux-ppc64le
 ucx:
 - 1.14.0
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/migrations/cuda_112_ppc64le_aarch64.yaml
+++ b/.ci_support/migrations/cuda_112_ppc64le_aarch64.yaml
@@ -17,6 +17,9 @@ __migrator:
   exclude_pinned_pkgs: False
   commit_message: "Rebuild for cuda for ppc64le and aarch64"
 
+arm_variant_type:              # [aarch64]
+  - sbsa                       # [aarch64]
+
 c_compiler_version:            # [ppc64le or aarch64]
   - 10                         # [ppc64le or aarch64]
 cxx_compiler_version:          # [ppc64le or aarch64]
@@ -24,6 +27,8 @@ cxx_compiler_version:          # [ppc64le or aarch64]
 fortran_compiler_version:      # [ppc64le or aarch64]
   - 10                         # [ppc64le or aarch64]
 
+cuda_compiler:                 # [ppc64le or aarch64]
+  - nvcc                       # [ppc64le or aarch64]
 cuda_compiler_version:         # [ppc64le or aarch64]
   - 11.2                       # [ppc64le or aarch64]
 
@@ -34,5 +39,9 @@ cdt_name:  # [ppc64le or aarch64]
   - cos7   # [ppc64le or aarch64]
 
 docker_image:                                           # [os.environ.get("BUILD_PLATFORM", "").startswith("linux") and (ppc64le or aarch64)]
+   # case: native compilation (build == target)
    - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2   # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
    - quay.io/condaforge/linux-anvil-aarch64-cuda:11.2   # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+   # case: cross-compilation (build != target)
+   - quay.io/condaforge/linux-anvil-cuda:11.2           # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+   - quay.io/condaforge/linux-anvil-cuda:11.2           # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]

--- a/.ci_support/migrations/cuda_112_ppc64le_aarch64.yaml
+++ b/.ci_support/migrations/cuda_112_ppc64le_aarch64.yaml
@@ -2,6 +2,7 @@ migrator_ts: 1645421738
 __migrator:
   kind:
     version
+  use_local: true
   migration_number:
     1
   build_number:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64-cuda:11.2
+    - env: CONFIG=linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64-cuda:11.2
       os: linux
       arch: arm64
       dist: focal
 
-    - env: CONFIG=linux_ppc64le_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10 UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2
+    - env: CONFIG=linux_ppc64le_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10 UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2
       os: linux
       arch: ppc64le
       dist: focal

--- a/README.md
+++ b/README.md
@@ -53,45 +53,45 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_c_compiler_version10cdt_namecos7cuda_compiler_version11.1cxx_compiler_version10</td>
+              <td>linux_64_c_compiler_version10cdt_namecos7cuda_compilernvcccuda_compiler_version11.1cxx_compiler_version10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version10cdt_namecos7cuda_compiler_version11.1cxx_compiler_version10" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version10cdt_namecos7cuda_compilernvcccuda_compiler_version11.1cxx_compiler_version10" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version10cdt_namecos7cuda_compiler_version11.2cxx_compiler_version10</td>
+              <td>linux_64_c_compiler_version10cdt_namecos7cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version10cdt_namecos7cuda_compiler_version11.2cxx_compiler_version10" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version10cdt_namecos7cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version7cdt_namecos6cuda_compiler_version10.2cxx_compiler_version7</td>
+              <td>linux_64_c_compiler_version7cdt_namecos6cuda_compilernvcccuda_compiler_version10.2cxx_compiler_version7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version7cdt_namecos6cuda_compiler_version10.2cxx_compiler_version7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version7cdt_namecos6cuda_compilernvcccuda_compiler_version10.2cxx_compiler_version7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version9cdt_namecos7cuda_compiler_version11.0cxx_compiler_version9</td>
+              <td>linux_64_c_compiler_version9cdt_namecos7cuda_compilernvcccuda_compiler_version11.0cxx_compiler_version9</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version9cdt_namecos7cuda_compiler_version11.0cxx_compiler_version9" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version9cdt_namecos7cuda_compilernvcccuda_compiler_version11.0cxx_compiler_version9" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10</td>
+              <td>linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10</td>
+              <td>linux_ppc64le_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10" alt="variant">
                 </a>
               </td>
             </tr>


### PR DESCRIPTION
Testing out the changes in PR ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4407 ) to add `cuda_compiler` to `zip_keys`. Also copies over the CUDA arch migrator changes and uses the local copy of that to test those work ok too.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
