### PR TITLE
Do not call ./autogen.sh and use release tarball

### DIFF
--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -10,7 +10,6 @@ elif [[ "${cuda_compiler_version}" != "None" ]]; then
   EXTRA_ARGS="${EXTRA_ARGS} --with-cuda=${CUDA_HOME}"
 fi
 
-./autogen.sh
 ./contrib/configure-release \
     --build="${BUILD}" \
     --host="${HOST}" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   skip: true  # [not linux or cuda_compiler_version == "None"]
-  number: 3
+  number: 4
 
 outputs:
   - name: ucx

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,8 +4,8 @@ package:
   name: ucx-split
 
 source:
-  url: https://github.com/openucx/ucx/archive/v{{ version }}.tar.gz
-  sha256: bf1c1ce6583ea1ab805feceb000157dc1fb825a60ddac0fbd9a329a010f9ad72
+  url: https://github.com/openucx/ucx/releases/download/v{{ version }}/ucx-{{ version }}.tar.gz
+  sha256: f73770d3b583c91aba5fb07557e655ead0786e057018bfe42f0ebe8716e9d28c
 
 build:
   skip: true  # [not linux or cuda_compiler_version == "None"]


### PR DESCRIPTION
./autogen.sh will incorrectly update the git commit hash that will be later on shown by ucx_info. Also, without ./sutogen, we can use the release tarballs instead of the raw source tarballs.
Resovles https://github.com/conda-forge/ucx-split-feedstock/issues/180 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
