### PR TITLE
disable UCX_MEM_EVENTS during conda-build on likely emulated platforms

### DIFF
--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -37,3 +37,6 @@ make -j${CPU_COUNT}
 make install
 
 cp "${RECIPE_DIR}/ucx-post-link.sh" "${PREFIX}/bin/.ucx-post-link.sh"
+
+mkdir -p "${PREFIX}/etc/conda/activate.d"
+cp -v "${RECIPE_DIR}/ucx-activate.sh" "${PREFIX}/etc/conda/activate.d/"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   skip: true  # [(not linux) or cuda_compiler_version in (undefined, "None", "12.6")]
-  number: 1
+  number: 2
 
 outputs:
   - name: ucx

--- a/recipe/ucx-activate.sh
+++ b/recipe/ucx-activate.sh
@@ -1,0 +1,7 @@
+if [ "${CONDA_BUILD:-}" = "1" ]; then
+  if [[ "${target_platform:-}" == "linux-aarch64" || "${target_platform:-}" == "linux-ppc64le" ]]; then
+    # disable UCX_MEM_EVENTS during build on likely emulated platforms,
+    # as it's known to segfault sometimes in these situations
+    export UCX_MEM_EVENTS="${UCX_MEM_EVENTS:-no}"
+  fi
+fi


### PR DESCRIPTION
via activation script

this is known to fail sometimes, and seems related to emulation in the build environment, not necessarily a bug likely to be seen by users during runtime

as such, only has an effect during conda builds on likely emulated platforms, so likely affects conda-forge CI for linux-aarch64/ppc64le and little else.

ref: https://github.com/conda-forge/mpi4py-feedstock/pull/87#issuecomment-2703526865 where this seems to be reliably causing crashes on emulated linux-aarch64 in combination with CPython 3.12 (loaded via mpich and openmpi), but not any other situation.

The same environment run elsewhere (e.g. in a container on my arm mac) does not see similar issues, which points to something peculiar in emulation, so this does not affect runtime installs.